### PR TITLE
fix unicorn.rb

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,23 +1,23 @@
 #サーバ上でのアプリケーションコードが設置されているディレクトリを変数に入れておく
-app_path = File.expand_path('../../../', __FILE__)
+@app_path = '/var/www/freemarket_sample_56c'
 
 #アプリケーションサーバの性能を決定するプロセスの数を表す
 worker_processes 1
 
 #アプリケーションの設置されているディレクトリを指定
-working_directory "#{app_path}/current"
+working_directory "#{@app_path}/current"
 
 #Unicornの起動に必要なファイルの設置場所を指定
-pid "#{app_path}/shared/tmp/pids/unicorn.pid"
+pid "#{@app_path}/shared/tmp/pids/unicorn.pid"
 
 #ポート番号を指定
-listen "#{app_path}/shared/tmp/sockets/unicorn.sock"
+listen "#{@app_path}/shared/tmp/sockets/unicorn.sock"
 
 #エラーのログを記録するファイルを指定
-stderr_path "#{app_path}/shared/log/unicorn.stderr.log"
+stderr_path "#{@app_path}/shared/log/unicorn.stderr.log"
 
 #通常のログを記録するファイルを指定
-stdout_path "#{app_path}/shared/log/unicorn.stdout.log"
+stdout_path "#{@app_path}/shared/log/unicorn.stdout.log"
 
 #Railsアプリケーションの応答を待つ上限時間を設定
 timeout 60


### PR DESCRIPTION
WHAT
unicorn.rbでエラーが出るために変数の定義の方法をカリキュラムとは違う方法に変更

WHY
unicorn.rbでエラーが出るため