### PR TITLE
Fix database and models

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@
 |brand_id|integer|null: false|
 |condition_id|integer|null: false|
 |delivery_fee_id|integer|null: false|
-|shipping_method|integer|null: false|
-|prefecture_from|integer|null: false|
-|shipping_days|integer|null: false|
+|shipping_method_id|integer|null: false|
+|prefecture_from_id|integer|null: false|
+|shipping_days_id|integer|null: false|
 |price|integer|null: false|
 
 ### Association

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,4 +1,5 @@
 class Address < ApplicationRecord
   belongs_to :user
+  extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to active_hash :prefecture
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -3,9 +3,10 @@ class Product < ApplicationRecord
   has_many :images 
   # has_many :comments
   has_many :users through :comments
-  belongs_to_active_hash :size_id
-  belongs_to_active_hash :condition_id
-  belongs_to_active_hash :delivery_fee_id
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :size
+  belongs_to_active_hash :condition
+  belongs_to_active_hash :delivery_fee
   belongs_to_active_hash :shipping_method
   belongs_to_active_hash :prefecture_from
   belongs_to_active_hash :shipping_days

--- a/db/migrate/20190812100938_rename_columns_to_products.rb
+++ b/db/migrate/20190812100938_rename_columns_to_products.rb
@@ -1,0 +1,7 @@
+class RenameColumnsToProducts < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :products, :shipping_method, :shipping_method_id
+    rename_column :products, :prefecture_from, :prefecture_from_id
+    rename_column :products, :shipping_days, :shipping_days_id
+  end
+end


### PR DESCRIPTION
# WHAT
- 外部キーであるのに「_id」が付いていなかったカラム名に「_id」を付加
- belongs_to_active_hashメソッドを使用する際、引数には「_id」が必要ないので該当部分の記述を削除

# WHY
正しくアソシエーションを呼べないことによって起こるエラーを解消するため