### PR TITLE
Modify path&view

### DIFF
--- a/app/assets/stylesheets/index.scss
+++ b/app/assets/stylesheets/index.scss
@@ -45,6 +45,9 @@
           width: 100%;
           display: flex;
           background-color: #f5f5f5;
+          &__link {
+            color: black;
+          }
           &__card{
             margin-left: 10px;
             margin-right: 10px;

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -10,19 +10,20 @@
         =link_to "", class: "item" do
           レディース 新着アイテム
       .contents__pickup__items__box__contents
-        - @products.each do |product|  
-          .contents__pickup__items__box__contents__card
-            .contents__pickup__items__box__contents__card__thumbnail
-              = image_tag product.images.first.image.url, size: '213x218'
-            .contents__pickup__items__box__contents__card__title
-              = product.name
-            .contents__pickup__items__box__contents__card__footer
-              .contents__pickup__items__box__contents__card__footer__price
-                ¥
-                = product.price
-              .contents__pickup__items__box__contents__card__footer__iine
-                = icon("far", "heart",class:"heart")
-                15
+        - @products.each do |product|
+          = link_to product_path(product.id),class: "contents__pickup__items__box__contents__link" do
+            .contents__pickup__items__box__contents__card
+              .contents__pickup__items__box__contents__card__thumbnail
+                = image_tag product.images.first.image.url, size: '213x218'
+              .contents__pickup__items__box__contents__card__title
+                = product.name
+              .contents__pickup__items__box__contents__card__footer
+                .contents__pickup__items__box__contents__card__footer__price
+                  ¥
+                  = product.price
+                .contents__pickup__items__box__contents__card__footer__iine
+                  = icon("far", "heart",class:"heart")
+                  15
    
       .contents__pickup__items__box__more
         =link_to "", class: "item" do
@@ -34,18 +35,19 @@
           メンズ 新着アイテム
       .contents__pickup__items__box__contents
         - @products.each do |product|  
-          .contents__pickup__items__box__contents__card
-            .contents__pickup__items__box__contents__card__thumbnail
-              = image_tag product.images.first.image.url, size: '213x218'
-            .contents__pickup__items__box__contents__card__title
-              = product.name
-            .contents__pickup__items__box__contents__card__footer
-              .contents__pickup__items__box__contents__card__footer__price
-                ¥
-                = product.price
-              .contents__pickup__items__box__contents__card__footer__iine
-                = icon("far", "heart",class:"heart")
-                15
+          = link_to product_path(product.id),class: "contents__pickup__items__box__contents__link" do
+            .contents__pickup__items__box__contents__card
+              .contents__pickup__items__box__contents__card__thumbnail
+                = image_tag product.images.first.image.url, size: '213x218'
+              .contents__pickup__items__box__contents__card__title
+                = product.name
+              .contents__pickup__items__box__contents__card__footer
+                .contents__pickup__items__box__contents__card__footer__price
+                  ¥
+                  = product.price
+                .contents__pickup__items__box__contents__card__footer__iine
+                  = icon("far", "heart",class:"heart")
+                  15
       .contents__pickup__items__box__more
         =link_to "", class: "item" do
           すべての商品を見る
@@ -56,18 +58,19 @@
           ベビー・キッズ 新着アイテム
       .contents__pickup__items__box__contents
         - @products.each do |product|  
-          .contents__pickup__items__box__contents__card
-            .contents__pickup__items__box__contents__card__thumbnail
-              = image_tag product.images.first.image.url, size: '213x218'
-            .contents__pickup__items__box__contents__card__title
-              = product.name
-            .contents__pickup__items__box__contents__card__footer
-              .contents__pickup__items__box__contents__card__footer__price
-                ¥
-                = product.price
-              .contents__pickup__items__box__contents__card__footer__iine
-                = icon("far", "heart",class:"heart")
-                15
+          = link_to product_path(product.id),class: "contents__pickup__items__box__contents__link" do
+            .contents__pickup__items__box__contents__card
+              .contents__pickup__items__box__contents__card__thumbnail
+                = image_tag product.images.first.image.url, size: '213x218'
+              .contents__pickup__items__box__contents__card__title
+                = product.name
+              .contents__pickup__items__box__contents__card__footer
+                .contents__pickup__items__box__contents__card__footer__price
+                  ¥
+                  = product.price
+                .contents__pickup__items__box__contents__card__footer__iine
+                  = icon("far", "heart",class:"heart")
+                  15
       .contents__pickup__items__box__more
         =link_to "", class: "item" do
           すべての商品を見る
@@ -78,18 +81,19 @@
           コスメ・香水・美容 新着アイテム
       .contents__pickup__items__box__contents
         - @products.each do |product|  
-          .contents__pickup__items__box__contents__card
-            .contents__pickup__items__box__contents__card__thumbnail
-              = image_tag product.images.first.image.url, size: '213x218'
-            .contents__pickup__items__box__contents__card__title
-              = product.name
-            .contents__pickup__items__box__contents__card__footer
-              .contents__pickup__items__box__contents__card__footer__price
-                ¥
-                = product.price
-              .contents__pickup__items__box__contents__card__footer__iine
-                = icon("far", "heart",class:"heart")
-                15
+          = link_to product_path(product.id),class: "contents__pickup__items__box__contents__link" do
+            .contents__pickup__items__box__contents__card
+              .contents__pickup__items__box__contents__card__thumbnail
+                = image_tag product.images.first.image.url, size: '213x218'
+              .contents__pickup__items__box__contents__card__title
+                = product.name
+              .contents__pickup__items__box__contents__card__footer
+                .contents__pickup__items__box__contents__card__footer__price
+                  ¥
+                  = product.price
+                .contents__pickup__items__box__contents__card__footer__iine
+                  = icon("far", "heart",class:"heart")
+                  15
       .contents__pickup__items__box__more
         =link_to "", class: "item" do
           すべての商品を見る
@@ -103,18 +107,19 @@
           シャネル 新着アイテム
       .contents__pickup__items__box__contents
         - @products.each do |product|  
-          .contents__pickup__items__box__contents__card
-            .contents__pickup__items__box__contents__card__thumbnail
-              = image_tag product.images.first.image.url, size: '213x218'
-            .contents__pickup__items__box__contents__card__title
-              = product.name
-            .contents__pickup__items__box__contents__card__footer
-              .contents__pickup__items__box__contents__card__footer__price
-                ¥
-                = product.price
-              .contents__pickup__items__box__contents__card__footer__iine
-                = icon("far", "heart",class:"heart")
-                15
+          = link_to product_path(product.id),class: "contents__pickup__items__box__contents__link" do
+            .contents__pickup__items__box__contents__card
+              .contents__pickup__items__box__contents__card__thumbnail
+                = image_tag product.images.first.image.url, size: '213x218'
+              .contents__pickup__items__box__contents__card__title
+                = product.name
+              .contents__pickup__items__box__contents__card__footer
+                .contents__pickup__items__box__contents__card__footer__price
+                  ¥
+                  = product.price
+                .contents__pickup__items__box__contents__card__footer__iine
+                  = icon("far", "heart",class:"heart")
+                  15
       .contents__pickup__items__box__more
         =link_to "", class: "item" do
           すべての商品を見る
@@ -125,18 +130,19 @@
           ルイビトン 新着アイテム
       .contents__pickup__items__box__contents
         - @products.each do |product|  
-          .contents__pickup__items__box__contents__card
-            .contents__pickup__items__box__contents__card__thumbnail
-              = image_tag product.images.first.image.url, size: '213x218'
-            .contents__pickup__items__box__contents__card__title
-              = product.name
-            .contents__pickup__items__box__contents__card__footer
-              .contents__pickup__items__box__contents__card__footer__price
-                ¥
-                = product.price
-              .contents__pickup__items__box__contents__card__footer__iine
-                = icon("far", "heart",class:"heart")
-                15
+          = link_to product_path(product.id),class: "contents__pickup__items__box__contents__link" do
+            .contents__pickup__items__box__contents__card
+              .contents__pickup__items__box__contents__card__thumbnail
+                = image_tag product.images.first.image.url, size: '213x218'
+              .contents__pickup__items__box__contents__card__title
+                = product.name
+              .contents__pickup__items__box__contents__card__footer
+                .contents__pickup__items__box__contents__card__footer__price
+                  ¥
+                  = product.price
+                .contents__pickup__items__box__contents__card__footer__iine
+                  = icon("far", "heart",class:"heart")
+                  15
       .contents__pickup__items__box__more
         =link_to "", class: "item" do
           すべての商品を見る
@@ -146,19 +152,20 @@
         =link_to "", class: "item" do
           シュプリーム 新着アイテム
       .contents__pickup__items__box__contents
-        - @products.each do |product|  
-          .contents__pickup__items__box__contents__card
-            .contents__pickup__items__box__contents__card__thumbnail
-              = image_tag product.images.first.image.url size: '213x218'
-            .contents__pickup__items__box__contents__card__title
-              = product.name
-            .contents__pickup__items__box__contents__card__footer
-              .contents__pickup__items__box__contents__card__footer__price
-                ¥
-                = product.price
-              .contents__pickup__items__box__contents__card__footer__iine
-                = icon("far", "heart",class:"heart")
-                15
+        - @products.each do |product|
+          = link_to product_path(product.id),class: "contents__pickup__items__box__contents__link" do
+            .contents__pickup__items__box__contents__card
+              .contents__pickup__items__box__contents__card__thumbnail
+                = image_tag product.images.first.image.url, size: '213x218'
+              .contents__pickup__items__box__contents__card__title
+                = product.name
+              .contents__pickup__items__box__contents__card__footer
+                .contents__pickup__items__box__contents__card__footer__price
+                  ¥
+                  = product.price
+                .contents__pickup__items__box__contents__card__footer__iine
+                  = icon("far", "heart",class:"heart")
+                  15
       .contents__pickup__items__box__more
         =link_to "", class: "item" do
           すべての商品を見る
@@ -169,18 +176,19 @@
           ナイキ 新着アイテム
       .contents__pickup__items__box__contents
         - @products.each do |product|  
-          .contents__pickup__items__box__contents__card
-            .contents__pickup__items__box__contents__card__thumbnail
-              = image_tag product.images.first.image.url, size: '213x218'
-            .contents__pickup__items__box__contents__card__title
-              = product.name
-            .contents__pickup__items__box__contents__card__footer
-              .contents__pickup__items__box__contents__card__footer__price
-                ¥
-                = product.price
-              .contents__pickup__items__box__contents__card__footer__iine
-                = icon("far", "heart",class:"heart")
-                15F
+          = link_to product_path(product.id),class: "contents__pickup__items__box__contents__link" do
+            .contents__pickup__items__box__contents__card
+              .contents__pickup__items__box__contents__card__thumbnail
+                = image_tag product.images.first.image.url, size: '213x218'
+              .contents__pickup__items__box__contents__card__title
+                = product.name
+              .contents__pickup__items__box__contents__card__footer
+                .contents__pickup__items__box__contents__card__footer__price
+                  ¥
+                  = product.price
+                .contents__pickup__items__box__contents__card__footer__iine
+                  = icon("far", "heart",class:"heart")
+                  15F
       .contents__pickup__items__box__more
         =link_to "", class: "item" do
           すべての商品を見る

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -76,7 +76,7 @@
         %span.item-container1__item-price-tax (税込)
         %span.item-container1__item-price-shipping-fee 送料込み
     - unless user_signed_in? && @product.user.id == current_user.id
-      = link_to " 購入画面に進む", product_purchase_path(@product.id),  class:"item-container1__item-buy-btn"
+      = link_to " 購入画面に進む", new_product_purchase_path(@product.id),  class:"item-container1__item-buy-btn"
     .item-container1__item-description 
       %p.item-description-inner
         = @product.detail
@@ -129,20 +129,21 @@
         .item-others--seller_product
           - @product.user.products.each do |product_other|
             - unless product_other.id == @product.id
-              .items-box
-                .items-box_photo
-                  -# = image_tag img.image, size: "220x220"
-                  -# = image_tag product_other.images.first.image, size: "220x220"
-                  = link_to image_tag("#{product_other.images.first.image.url}", size: "220x220"), product_path(product_other.id)  
-                .items-box_body
-                  %h3.items-box-name
-                    =product_other.name
-                  .items-box-num
-                    .items-box-price ￥
-                    =product_other.price.to_s(:delimited, delimiter: ',')
-                    .items-box-icon
-                      %i.fa.fa-heart
-                      1
+              = link_to product_path(product_other.id),class: "contents__pickup__items__box__contents__link" do
+                .items-box
+                  .items-box_photo
+                    -# = image_tag img.image, size: "220x220"
+                    -# = image_tag product_other.images.first.image, size: "220x220"
+                    = image_tag("#{product_other.images.first.image.url}", size: "220x220")
+                  .items-box_body
+                    %h3.items-box-name
+                      =product_other.name
+                    .items-box-num
+                      .items-box-price ￥
+                      =product_other.price.to_s(:delimited, delimiter: ',')
+                      .items-box-icon
+                        %i.fa.fa-heart
+                        1
 
     - unless @same_category_products.blank?
       %section.item-others--product
@@ -151,17 +152,18 @@
           その他の商品
         .item-others--product__content
         - @same_category_products.each do |product|
-          .items-box
-            .items-box_photo= link_to image_tag("#{product.images.first.image.url}", size: "220x220"), product_path(product.id)
-            .items-box_body
-              %h3.items-box-name
-                = product.name
-              .items-box-num
-                .items-box-price ￥
-                = product.price.to_s(:delimited, delimiter: ',')
-                .items-box-icon
-                  %i.fa.fa-heart
-                  2
+          = link_to product_path(product.id),class: "contents__pickup__items__box__contents__link" do
+            .items-box
+              .items-box_photo=image_tag("#{product.images.first.image.url}", size: "220x220")
+              .items-box_body
+                %h3.items-box-name
+                  = product.name
+                .items-box-num
+                  .items-box-price ￥
+                  = product.price.to_s(:delimited, delimiter: ',')
+                  .items-box-icon
+                    %i.fa.fa-heart
+                    2
         
 = render 'shared/footer'
 

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -132,8 +132,6 @@
               = link_to product_path(product_other.id),class: "contents__pickup__items__box__contents__link" do
                 .items-box
                   .items-box_photo
-                    -# = image_tag img.image, size: "220x220"
-                    -# = image_tag product_other.images.first.image, size: "220x220"
                     = image_tag("#{product_other.images.first.image.url}", size: "220x220")
                   .items-box_body
                     %h3.items-box-name


### PR DESCRIPTION
# What
productsのindex画面でのview崩れを修正
productsのindex画面において各カードから商品詳細ページに遷移できるようにpathを指定
productsのshow画面における購入ボタンへ埋め込んだpathの修正
productsのshow画面において各カードから他の商品詳細ページに遷移できるようにpathを指定

# Why
viewを整えるため。
index画面から本家仕様と同じく詳細画面を見れるようにするため。

# Gyazo
## index画面
https://gyazo.com/0d3bbad628bccfe6f2a9aeda5f81099e
https://gyazo.com/9019ccf68c7688cb1a9b4284c57c2d3a
https://gyazo.com/f2ebf6154c7ec1212f1e2322de5f52c3 → 写真の重なりを修正
## show画面
https://gyazo.com/ab90d36da8f95a0872da52515e7fb7f8
https://gyazo.com/5fd19de313319806d47a7a07eb422615 → 非ログイン状態の購入ボタン遷移先
