### PR TITLE
[WIP]Updated commission

### DIFF
--- a/app/assets/javascripts/price.js
+++ b/app/assets/javascripts/price.js
@@ -1,8 +1,3 @@
-// $(".input-default").addEventListener("keyup", function(){
-//   var $result;
-//   for (var $val of $)
-//   $('.l-right').text($result);
-// });
 $(function(){
   $("#product_price").on("keyup", function(){
     var input = $(this).val().toLocaleString();

--- a/app/assets/javascripts/price.js
+++ b/app/assets/javascripts/price.js
@@ -1,0 +1,21 @@
+// $(".input-default").addEventListener("keyup", function(){
+//   var $result;
+//   for (var $val of $)
+//   $('.l-right').text($result);
+// });
+$(function(){
+  $("#product_price").on("keyup", function(){
+    var input = $(this).val().toLocaleString();
+    var commission2 = Math.round(input * 0.1);
+    var result = (input - commission2).toLocaleString();
+    var commission = Math.round(input*0.1).toLocaleString();
+    if (input >= 300 && input <= 9999999){
+      $("#commission.l-right").text("¥"+commission);
+      $("#price.l-right").text("¥"+result);
+    } else { 
+      $("#commission.l-right").text("-");
+      $("#price.l-right").text("-");
+    }
+
+  });
+});

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -107,10 +107,10 @@
                       %li.clearfix
                         .l-left
                           販売手数料 (10%)
-                        .l-right -
+                        #commission.l-right -
                       %li.clearfix.bold
                         .l-left 販売利益
-                        .l-right -
+                        #price.l-right -
                 .modal.is-show{role: "dialog", tabindex:"-1"}
                   .modal-inner
                     %div

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,7 +62,7 @@ ActiveRecord::Schema.define(version: 2019_08_24_062428) do
     t.text "detail", null: false
     t.bigint "user_id", null: false
     t.integer "size_id", null: false
-    t.string "brand"
+    t.string "brand", default: ""
     t.integer "condition_id", null: false
     t.integer "delivery_fee_id", null: false
     t.integer "shipping_method_id", null: false


### PR DESCRIPTION
#WHAT
手数料及び売上計算をjQueryで実装しました。

具体的には以下の通りです。
①　300円以上かつ9,999,999円以下の場合のみ自動計算を実施。
②　千の桁毎にカンマを挿入。
https://gyazo.com/72e26a885718448e22e51d327aaa768f

#WHY
本家メルカリの通り、出品時に即座に実際の売上額を把握出来る様にする為。