### PR TITLE
Display category of product show and change description

### DIFF
--- a/app/assets/stylesheets/products.scss
+++ b/app/assets/stylesheets/products.scss
@@ -458,6 +458,7 @@ body {
 }
 .blue{
   color: #0099e8;
+  font-size: 13px;
 }
 #child_category{
   position: relative;

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -37,7 +37,6 @@ class ProductsController < ApplicationController
   end
     
   def index
-    @search = Product.ransack()
     @products = Product.order(id: :desc).limit(4)
   end
   

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -26,18 +26,16 @@
                 - parent=@product.category.path_ids[0].to_i
                 = @category.find(parent).name
               %br  
-              %i.fas.fa-angle-right 
-                = link_to '#',class:"blue" do
-                  トップス
-                  -# - child=@product.category.path_ids[1].to_i
-                  -# = @category.find(child).name 
+              = link_to '#',class:"blue" do
+                %i.fas.fa-angle-right 
+                - child=@product.category.path_ids[1].to_i
+                = @category.find(child).name 
                  
               %br 
-              %i.fas.fa-angle-right 
-                = link_to '#',class:"blue" do
-                  Tシャツ/カットソー(半袖/袖なし)
-                  -# - grandchild=@product.category.path_ids[2].to_i
-                  -# = @category.find(grandchild).name
+              = link_to '#',class:"blue" do
+                %i.fas.fa-angle-right 
+                - grandchild=@product.category.path_ids[2].to_i
+                = @category.find(grandchild).name
                  
           //params[:id]で取得したidの商品に対してcategory子、孫も表示するために記載//
           %tr.table--section

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -14,7 +14,7 @@
           =link_to "", class: "menu" do
             .header__top__contents__icons__mypage__thumbnail
     .header__top__search
-      = search_form_for @search, url: search_products_path ,html: { method: :post } do |f|
+      = search_form_for Product.ransack, url: search_products_path ,html: { method: :post } do |f|
         .field
           = f.search_field :name_cont,placeholder: "何かお探しですか？" ,class: 'search'
           = f.submit "",class:'submit', name: nil


### PR DESCRIPTION
# What
商品詳細画面に商品のカテゴリーである子要素、孫要素を表示できるように実装。
インスタンス変数を削除し、モデルクラスメソッドをformに記載。

# Why
商品詳細ページの実装を充実させ、userに適切な情報を与えるため。
インスタンス変数の呼び出し先であるviewpageにエラーが発生していたため。

# Gyazo
https://gyazo.com/59715c837c2638566d90af89a44f2685