### PR TITLE
Change sales status and security code columns

### DIFF
--- a/db/migrate/20190827014522_remove_sales_status_from_products.rb
+++ b/db/migrate/20190827014522_remove_sales_status_from_products.rb
@@ -1,0 +1,5 @@
+class RemoveSalesStatusFromProducts < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :products, :sales_status, :integer
+  end
+end

--- a/db/migrate/20190827022312_change_datatype_security_code_of_cards.rb
+++ b/db/migrate/20190827022312_change_datatype_security_code_of_cards.rb
@@ -1,0 +1,5 @@
+class ChangeDatatypeSecurityCodeOfCards < ActiveRecord::Migration[5.2]
+  def change
+    change_column :cards, :security_code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_24_062428) do
+ActiveRecord::Schema.define(version: 2019_08_27_022312) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "postal_code", null: false
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 2019_08_24_062428) do
   create_table "cards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "number", null: false
     t.date "expiration_date", null: false
-    t.integer "security_code", null: false
+    t.string "security_code", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -62,7 +62,7 @@ ActiveRecord::Schema.define(version: 2019_08_24_062428) do
     t.text "detail", null: false
     t.bigint "user_id", null: false
     t.integer "size_id", null: false
-    t.string "brand", default: ""
+    t.string "brand"
     t.integer "condition_id", null: false
     t.integer "delivery_fee_id", null: false
     t.integer "shipping_method_id", null: false
@@ -72,7 +72,6 @@ ActiveRecord::Schema.define(version: 2019_08_24_062428) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "category_id", null: false
-    t.integer "sales_status"
     t.integer "status", null: false
     t.index ["category_id"], name: "index_products_on_category_id"
     t.index ["user_id"], name: "index_products_on_user_id"


### PR DESCRIPTION
# WHAT
- productsテーブルのsales_statusカラムを削除
- cardsテーブルのsecurity_codeカラムをinteger型からstring型に変更

# WHY
- sales_statusカラムがstatusカラムと重複していたため
- security_codeカラムがintegerだと不適切なため（たとえば、012というセキュリティーコードを入力した場合、データベースに整数値12が入力されてしまう）